### PR TITLE
Change `withState` return type to Unit

### DIFF
--- a/async-state/src/commonMain/kotlin/io/github/anvell/async/state/AsyncState.kt
+++ b/async-state/src/commonMain/kotlin/io/github/anvell/async/state/AsyncState.kt
@@ -29,7 +29,9 @@ interface AsyncState<S> {
     /**
      * Provide current state in [block]
      */
-    fun <V> withState(block: (S) -> V) = block(stateFlow.value)
+    fun <V> withState(block: (state: S) -> V) {
+        block(stateFlow.value)
+    }
 
     /**
      * Update current state with [reducer].

--- a/async-state/src/commonMain/kotlin/io/github/anvell/async/state/AsyncState.kt
+++ b/async-state/src/commonMain/kotlin/io/github/anvell/async/state/AsyncState.kt
@@ -29,9 +29,7 @@ interface AsyncState<S> {
     /**
      * Provide current state in [block]
      */
-    fun <V> withState(block: (state: S) -> V) {
-        block(stateFlow.value)
-    }
+    fun withState(block: (state: S) -> Unit) = block(stateFlow.value)
 
     /**
      * Update current state with [reducer].

--- a/async-state/src/commonTest/kotlin/io.github.anvell.async.state/AsyncStateTest.kt
+++ b/async-state/src/commonTest/kotlin/io.github.anvell.async.state/AsyncStateTest.kt
@@ -21,9 +21,13 @@ class AsyncStateTest : AsyncState<MockData> by AsyncState.Delegate(MockData()) {
 
     @Test
     fun changeStateDirectly() {
-        assertEquals(withState(MockData::text), Uninitialized)
+        withState { state ->
+            assertEquals(state.text, Uninitialized)
+        }
         setState { copy(text = Success("some text")) }
-        assertEquals(withState(MockData::text), Success("some text"))
+        withState { state ->
+            assertEquals(state.text, Success("some text"))
+        }
     }
 
     @Test


### PR DESCRIPTION
Change return type to `Unit` to discourage using multiple following calls to `withState`.